### PR TITLE
Add `!` versions of save and update

### DIFF
--- a/spec/form_spec.cr
+++ b/spec/form_spec.cr
@@ -243,7 +243,10 @@ describe "LuckyRecord::Form" do
       it "raises an exception" do
         params = {"name" => "", "age" => "30"}
 
-        expect_raises(LuckyRecord::InvalidFormError) do
+        expect_raises(
+          LuckyRecord::InvalidFormError(UserForm),
+          /Invalid UserForm. Could not save/
+        ) do
           UserForm.save!(params)
         end
       end
@@ -296,7 +299,10 @@ describe "LuckyRecord::Form" do
         user = UserQuery.new.first
         params = {"name" => ""}
 
-        expect_raises(LuckyRecord::InvalidFormError) do
+        expect_raises(
+          LuckyRecord::InvalidFormError(UserForm),
+          /Invalid UserForm. Could not save/
+        ) do
           UserForm.update! user, with: params
         end
       end

--- a/spec/form_spec.cr
+++ b/spec/form_spec.cr
@@ -227,6 +227,29 @@ describe "LuckyRecord::Form" do
     end
   end
 
+  describe ".save!" do
+    context "on success" do
+      it "saves and returns the record" do
+        params = {"joined_at" => now_as_string, "name" => "New Name", "age" => "30"}
+
+        record = UserForm.save!(params)
+
+        record.is_a?(User).should be_true
+        record.name.should eq "New Name"
+      end
+    end
+
+    context "on failure" do
+      it "raises an exception" do
+        params = {"name" => "", "age" => "30"}
+
+        expect_raises(LuckyRecord::InvalidFormError) do
+          UserForm.save!(params)
+        end
+      end
+    end
+  end
+
   describe ".update" do
     context "on success" do
       it "yields the form and the updated record" do

--- a/spec/form_spec.cr
+++ b/spec/form_spec.cr
@@ -275,4 +275,31 @@ describe "LuckyRecord::Form" do
       end
     end
   end
+
+  describe ".update!" do
+    context "on success" do
+      it "updates and returns the record" do
+        create_user(name: "Old Name")
+        user = UserQuery.new.first
+        params = {"name" => "New Name"}
+
+        record = UserForm.update! user, with: params
+
+        record.is_a?(User).should be_true
+        record.name.should eq "New Name"
+      end
+    end
+
+    context "on failure" do
+      it "raises an exception" do
+        create_user(name: "Old Name")
+        user = UserQuery.new.first
+        params = {"name" => ""}
+
+        expect_raises(LuckyRecord::InvalidFormError) do
+          UserForm.update! user, with: params
+        end
+      end
+    end
+  end
 end

--- a/src/lucky_record/errors.cr
+++ b/src/lucky_record/errors.cr
@@ -11,4 +11,8 @@ module LuckyRecord
       super "Could not find #{model} with id of #{id}"
     end
   end
+
+  # Raised when using the save! or update! methods on a form when it does not have the proper attributes
+  class InvalidFormError < LuckyRecordError
+  end
 end

--- a/src/lucky_record/errors.cr
+++ b/src/lucky_record/errors.cr
@@ -13,6 +13,12 @@ module LuckyRecord
   end
 
   # Raised when using the save! or update! methods on a form when it does not have the proper attributes
-  class InvalidFormError < LuckyRecordError
+  class InvalidFormError(T) < LuckyRecordError
+    getter form_name
+    getter form_object
+
+    def initialize(@form_name : String, @form_object : T)
+      super "Invalid #{form_name}. Could not save #{@form_object}"
+    end
   end
 end

--- a/src/lucky_record/form.cr
+++ b/src/lucky_record/form.cr
@@ -171,7 +171,7 @@ abstract class LuckyRecord::Form(T)
     if save
       record.not_nil!
     else
-      raise LuckyRecord::InvalidFormError.new("#{record} has invalid parameters")
+      raise LuckyRecord::InvalidFormError.new(form_name: typeof(self).to_s, form_object: self)
     end
   end
 

--- a/src/lucky_record/form.cr
+++ b/src/lucky_record/form.cr
@@ -175,6 +175,10 @@ abstract class LuckyRecord::Form(T)
     end
   end
 
+  def update! : T
+    save!
+  end
+
   private def insert_or_update
     if record_id
       update record_id

--- a/src/lucky_record/form.cr
+++ b/src/lucky_record/form.cr
@@ -167,6 +167,14 @@ abstract class LuckyRecord::Form(T)
     end
   end
 
+  def save! : T
+    if save
+      record.not_nil!
+    else
+      raise LuckyRecord::InvalidFormError.new("#{record} has invalid parameters")
+    end
+  end
+
   private def insert_or_update
     if record_id
       update record_id

--- a/src/lucky_record/needy_initializer.cr
+++ b/src/lucky_record/needy_initializer.cr
@@ -53,6 +53,20 @@ module LuckyRecord::NeedyInitializer
       end
     end
 
+    def self.save!(
+        params,
+        {% if NEEDS.size > 0 %}
+          **needs
+        {% end %}
+      )
+      form = new(
+        params,
+        {% if NEEDS.size > 0 %}
+          **needs
+        {% end %}
+      ).save!
+    end
+
     def self.update(
         record,
         with params,

--- a/src/lucky_record/needy_initializer.cr
+++ b/src/lucky_record/needy_initializer.cr
@@ -87,6 +87,22 @@ module LuckyRecord::NeedyInitializer
         yield form, form.record.not_nil!
       end
     end
+
+    def self.update!(
+        record,
+        with params,
+        {% if NEEDS.size > 0 %}
+          **needs
+        {% end %}
+      )
+      form = new(
+        record,
+        params,
+        {% if NEEDS.size > 0 %}
+          **needs
+        {% end %}
+      ).update!
+    end
   end
 
   macro generate_getters


### PR DESCRIPTION
Fixes #66 

These methods will work like the normal `save` and `update`, but only take parameters and no block. If it saves successfully, it will return the record, _not_ the form. If it fails, it will raise a LuckyRecord::Exceptions::InvalidForm error.

I tried to use the existing logic where it made sense, since the goal is for the method to work the same but have some different behavior after the record is saved (or not).

I took the hierarchy pattern for the error from LuckyWeb's exception module.