### PR TITLE
Add allow_virtual

### DIFF
--- a/spec/allow_virtual_spec.cr
+++ b/spec/allow_virtual_spec.cr
@@ -1,0 +1,36 @@
+require "./spec_helper"
+
+private class VirtualForm < User::BaseForm
+  allow_virtual password_confirmation
+
+  def prepare
+    password_confirmation.value = "reset"
+  end
+end
+
+describe "allow_virtual in forms" do
+  it "is an AllowedField" do
+    form.password_confirmation.should be_a(LuckyRecord::AllowedField(String?))
+    form.password_confirmation.name.should eq(:password_confirmation)
+    form.password_confirmation.form_name.should eq("virtual")
+  end
+
+  it "sets the param and value basd on the passed in params" do
+    form = form({"password_confirmation" => "password"})
+
+    form.password_confirmation.value.should eq "password"
+    form.password_confirmation.param.should eq "password"
+  end
+
+  it "is memoized so you can change the field in `prepare`" do
+    form = form({"password_confirmation" => "password"})
+    form.password_confirmation.value.should eq "password"
+
+    form.prepare
+    form.password_confirmation.value.should eq "reset"
+  end
+end
+
+private def form(attrs = {} of String => String)
+  VirtualForm.new(attrs)
+end

--- a/src/lucky_record/allow_virtual.cr
+++ b/src/lucky_record/allow_virtual.cr
@@ -1,0 +1,22 @@
+module LuckyRecord::AllowVirtual
+  macro allow_virtual(name)
+    @_{{ name }} : LuckyRecord::Field(String?)?
+
+    def {{ name }}
+      LuckyRecord::AllowedField.new(_{{ name }})
+    end
+
+    private def _{{ name }}
+      @_{{ name }} ||= LuckyRecord::Field(String?).new(
+        name: :{{ name }},
+        param: {{ name }}_param,
+        value: {{ name }}_param,
+        form_name: form_name
+      )
+    end
+
+    private def {{ name }}_param
+      params.nested!(form_name)["{{ name }}"]?
+    end
+  end
+end

--- a/src/lucky_record/form.cr
+++ b/src/lucky_record/form.cr
@@ -4,6 +4,7 @@ require "./needy_initializer"
 abstract class LuckyRecord::Form(T)
   include LuckyRecord::Validations
   include LuckyRecord::NeedyInitializer
+  include LuckyRecord::AllowVirtual
 
   macro inherited
     @valid : Bool = true


### PR DESCRIPTION
Closes #76

This does not allow setting a type. The virtual field is always a
String. This is not ideal long term, but it works for now. You can
always parse the type yourself in the form if you need something other
than a String.