### PR TITLE
Open connection once. Huge performance boost

### DIFF
--- a/src/lucky_record/repo.cr
+++ b/src/lucky_record/repo.cr
@@ -1,11 +1,15 @@
 class LuckyRecord::Repo
+  @@db : DB::Database? = nil
+
   Habitat.create do
     setting url : String
   end
 
   def self.run
-    DB.open(settings.url) do |db|
-      yield db
-    end
+    yield db
+  end
+
+  def self.db
+    @@db ||= DB.open(settings.url)
   end
 end


### PR DESCRIPTION
Closes #98

It takes 5-10ms to open the db. So doing this for EVERY query/exec
results in very poor performance. Now we open it once. Just did a test
of loading/decoding 1_000 super simple records and it took 1.01ms.
Before it was 10-11.