### PR TITLE
Add aggregate 'count' to query builder/queryable

### DIFF
--- a/spec/query_builder_spec.cr
+++ b/spec/query_builder_spec.cr
@@ -46,6 +46,15 @@ describe "LuckyRecord::QueryBuilder" do
       query.args_for_update(params).should eq ["Paul", "Smith", "1"]
     end
   end
+
+  it "can be counted" do
+    query = LuckyRecord::QueryBuilder
+      .new(table: :users)
+      .count
+
+    query.statement.should eq "SELECT COUNT(*) FROM users"
+    query.args.should eq [] of String
+  end
 end
 
 private def new_query

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -80,6 +80,17 @@ describe LuckyRecord::Query do
       query.statement.should eq "SELECT * FROM users ORDER BY name ASC"
     end
   end
+
+  describe "#count" do
+    it "returns the number of database rows" do
+      count = UserQuery.new.count
+      count.should eq 0
+
+      insert_a_user
+      count = UserQuery.new.count
+      count.should eq 1
+    end
+  end
 end
 
 private def insert_a_user

--- a/src/lucky_record/query_builder.cr
+++ b/src/lucky_record/query_builder.cr
@@ -6,7 +6,7 @@ class LuckyRecord::QueryBuilder
     asc:  [] of Symbol | String,
     desc: [] of Symbol | String,
   }
-  @selections = "*"
+  @selections : String = "*"
   @prepared_statement_placeholder = 0
 
   VALID_DIRECTIONS = [:asc, :desc]

--- a/src/lucky_record/query_builder.cr
+++ b/src/lucky_record/query_builder.cr
@@ -6,6 +6,7 @@ class LuckyRecord::QueryBuilder
     asc:  [] of Symbol | String,
     desc: [] of Symbol | String,
   }
+  @selections = "*"
   @prepared_statement_placeholder = 0
 
   VALID_DIRECTIONS = [:asc, :desc]
@@ -69,6 +70,11 @@ class LuckyRecord::QueryBuilder
     end
   end
 
+  def count
+    @selections = "COUNT(*)"
+    self
+  end
+
   private def ordered?
     @orders.values.any? do |columns|
       !columns.empty?
@@ -76,7 +82,7 @@ class LuckyRecord::QueryBuilder
   end
 
   private def select_sql
-    "SELECT * FROM #{table}"
+    "SELECT #{@selections} FROM #{table}"
   end
 
   private def limit_sql

--- a/src/lucky_record/queryable.cr
+++ b/src/lucky_record/queryable.cr
@@ -37,9 +37,9 @@ module LuckyRecord::Queryable(T)
     exec_query.first
   end
 
-  def count
+  def count : Int64
     query.count
-    exec_scalar
+    exec_scalar.as(Int64)
   end
 
   def each

--- a/src/lucky_record/queryable.cr
+++ b/src/lucky_record/queryable.cr
@@ -37,6 +37,11 @@ module LuckyRecord::Queryable(T)
     exec_query.first
   end
 
+  def count
+    query.count
+    exec_scalar
+  end
+
   def each
     results.each do |result|
       yield result
@@ -52,6 +57,12 @@ module LuckyRecord::Queryable(T)
       db.query query.statement, query.args do |rs|
         @@schema_class.from_rs(rs)
       end
+    end
+  end
+
+  private def exec_scalar
+    LuckyRecord::Repo.run do |db|
+      db.scalar query.statement
     end
   end
 


### PR DESCRIPTION
This should add support for queries like `UserQuery.new.company.lower.is("thoughtbot").count`. Forgive me if anything is absolutely misplaced, just finding my way around in here :) I guess this also has some relation to #90.

Edit:

Should the `LuckyRecord::QueryBuilder` somehow be "closed" after calling `.count`?
I guess things like
```crystal
    query = LuckyRecord::QueryBuilder
      .new(table: :users)
      .count
      .order_by(:email, :desc)
```
wouldn't make too much sense?    
